### PR TITLE
fix(node): set `--localstorage-file` via launcher for tsx (silence store2 / localStorage warning on Node 22+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.7",
   "description": "",
   "scripts": {
-    "start": "tsx -r tsconfig-paths/register ./src/index.ts",
-    "tpm": "tsx -r tsconfig-paths/register ./src/plugin/tpm.ts",
-    "dev": "NODE_ENV=development tsx -r tsconfig-paths/register ./src/index.ts"
+    "start": "node scripts/run-tsx.cjs ./src/index.ts",
+    "tpm": "node scripts/run-tsx.cjs ./src/plugin/tpm.ts",
+    "dev": "NODE_ENV=development node scripts/run-tsx.cjs ./src/index.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/run-tsx.cjs
+++ b/scripts/run-tsx.cjs
@@ -1,0 +1,39 @@
+'use strict';
+/**
+ * Node 22+ exposes global localStorage backed by --localstorage-file.
+ * teleproto → store2 touches localStorage at load time; without a valid path,
+ * Node warns. tsx may spawn child Node processes that only inherit env, not
+ * the parent argv flag — so this sets NODE_OPTIONS (merged with any existing).
+ *
+ * Override file path with TB_LOCALSTORAGE_FILE.
+ */
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const root = path.join(__dirname, '..');
+const cacheBase = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+const defaultFile = path.join(cacheBase, 'telebox', 'node-localstorage');
+const lsFile = process.env.TB_LOCALSTORAGE_FILE || defaultFile;
+
+fs.mkdirSync(path.dirname(lsFile), { recursive: true });
+
+const tsxCli = path.join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const entryArgs = process.argv.slice(2);
+if (entryArgs.length === 0) {
+  console.error('usage: node scripts/run-tsx.cjs <script.ts> [args...]');
+  process.exit(1);
+}
+
+const env = { ...process.env };
+const flag = `--localstorage-file=${lsFile}`;
+const existing = (env.NODE_OPTIONS || '').trim();
+env.NODE_OPTIONS = existing ? `${existing} ${flag}` : flag;
+
+const r = spawnSync(
+  process.execPath,
+  [tsxCli, '-r', 'tsconfig-paths/register', ...entryArgs],
+  { cwd: root, env, stdio: 'inherit' }
+);
+process.exit(r.status === null ? 1 : r.status);


### PR DESCRIPTION
### 背景

在 **Node.js 22+**（含 25.x）下，依赖链 **`teleproto` → `store2`** 在加载时会探测 `globalThis.localStorage`。Node 内置 Web Storage 需要有效的 **`--localstorage-file`** 持久化路径；未满足时会在启动阶段打印警告（部分环境下日志级别会显示为 `[ERROR]`，实为 Node 的 **Warning**）。

另外，**`tsx` 会启动子 Node 进程**，子进程主要继承 **环境变量**，仅给最外层 `node` 传 CLI 参数往往不够，因此通过启动脚本统一设置 **`NODE_OPTIONS`**（并与用户已有 `NODE_OPTIONS` 合并）更可靠。

### 改动摘要

- 新增 `scripts/run-tsx.cjs`：默认使用 `$XDG_CACHE_HOME/telebox/node-localstorage`（未设置 `XDG_CACHE_HOME` 时回退为 `~/.cache/telebox/node-localstorage`），启动前创建父目录；可通过 **`TB_LOCALSTORAGE_FILE`** 覆盖路径。
- `package.json` 的 `start` / `dev` / `tpm` 改为经上述脚本调用 `tsx`，避免在三条脚本里重复冗长 shell。

### 修复前 / 修复后（脱敏日志摘录）

**环境说明**：Node 25.x；项目路径记为 `<project-root>`；进程号已匿名。

<details>
<summary>修复前（存在 <code>localstorage-file</code> 警告及栈）</summary>

```text
$ NODE_OPTIONS='--trace-warnings' npm start

> telebox@0.2.7 start
> tsx -r tsconfig-paths/register ./src/index.ts

[INFO] [Running teleproto version 1.224.0]
[INFO] [loginManager.ts:40] Connecting to Telegram...
[INFO] [Connecting to 91.108.xx.xx:443/TCPFull...]
[ERROR] [node:events:508] (node:xxxxx) Warning: `--localstorage-file` was provided without a valid path
    at Object.get (node:internal/webstorage:32:25)
    at Object.Store (<project-root>/node_modules/store2/dist/store2.js:55:22)
    at <project-root>/node_modules/store2/dist/store2.js:264:11
    at Object.<anonymous> (<project-root>/node_modules/store2/dist/store2.js:283:3)
    at Object.transformer (<project-root>/node_modules/tsx/dist/register-D46fvsV_.cjs:3:1104)
    ...
[INFO] [Connection to 91.108.xx.xx:443/TCPFull complete!]
[INFO] ✅ Existing session detected. Logged in successfully.
```

（其后若出现断线重连、RPC 等与本次警告无关的日志，此处从略。）

</details>

<details>
<summary>修复后（同阶段无上述警告）</summary>

```text
$ npm start

> telebox@0.2.7 start
> node scripts/run-tsx.cjs ./src/index.ts

[INFO] [Running teleproto version 1.224.0]
[INFO] [loginManager.ts:40] Connecting to Telegram...
[INFO] [Connecting to 91.108.xx.xx:443/TCPFull...]
[INFO] [Connection to 91.108.xx.xx:443/TCPFull complete!]
[INFO] [Using LAYER 224 for initial connect]
[INFO] ✅ Existing session detected. Logged in successfully.
```

</details>

### 说明

- 该文件仅用于满足 Node 对内置 `localStorage` 的后端要求；**与 Telegram 会话文件等业务数据无直接关系**。
- 若需自定义路径，可设置环境变量 **`TB_LOCALSTORAGE_FILE`**。
- 若直接使用 `tsx` 而不走 `npm` 脚本，需自行保证子进程能继承含 `--localstorage-file=...` 的 **`NODE_OPTIONS`**。
