### PR TITLE
fix(version): append git commit hash to local display

### DIFF
--- a/src/plugin/help.ts
+++ b/src/plugin/help.ts
@@ -4,8 +4,7 @@ import {
   getPrefixes,
 } from "@utils/pluginManager";
 import { Plugin } from "@utils/pluginBase";
-import fs from "fs";
-import path from "path";
+import { readDisplayVersion } from "@utils/teleboxInfoHelper";
 import { Api } from "teleproto";
 import { AliasDB } from "@utils/aliasDB";
 
@@ -38,17 +37,6 @@ function htmlEscape(text: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
-}
-
-function readVersion(): string {
-  try {
-    const pkg = JSON.parse(
-      fs.readFileSync(path.join(process.cwd(), "package.json"), "utf-8")
-    );
-    return pkg.version || "未知版本";
-  } catch {
-    return "未知版本";
-  }
 }
 
 /* ============================================================
@@ -191,7 +179,7 @@ class HelpPlugin extends Plugin {
         // 预扣：header bold(1) + 前缀数量 + prefixLine bold(1) + helpTip codes(2) + links(5)
         mainPlanner.consume(1 + prefixes.length + 1 + 2 + 5);
 
-        const header = `🚀 <b>TeleBox v${htmlEscape(readVersion())}</b> | ${commands.length} 个命令`;
+        const header = `🚀 <b>TeleBox v${htmlEscape(readDisplayVersion())}</b> | ${commands.length} 个命令`;
         const basic = formatBasicCommands(commands, mainPlanner);
         const prefixLine = `❕ <b>指令前缀：</b> ${prefixes.map(p => `<code>${htmlEscape(p)}</code>`).join(" • ")}`;
         const helpTip = `💡 <code>${mainPrefix}help [命令]</code> 查看详情 | <code>${mainPrefix}tpm search</code> 显示远程插件列表`;

--- a/src/plugin/status.ts
+++ b/src/plugin/status.ts
@@ -1,5 +1,6 @@
 import { Plugin } from "@utils/pluginBase";
 import { getPrefixes } from "@utils/pluginManager";
+import { readDisplayVersion } from "@utils/teleboxInfoHelper";
 import { Api } from "teleproto";
 import * as os from "os";
 import * as fs from "fs";
@@ -756,13 +757,13 @@ Scan Time: ${scanTime}ms
       return {
         nodejs: process.version,
         teleproto: packageJson.dependencies?.teleproto?.replace('^', '') || 'unknown',
-        telebox: packageJson.version || 'unknown'
+        telebox: readDisplayVersion()
       };
     } catch {
       return {
         nodejs: process.version,
         teleproto: 'unknown',
-        telebox: 'unknown'
+        telebox: readDisplayVersion()
       };
     }
   }

--- a/src/utils/teleboxInfoHelper.ts
+++ b/src/utils/teleboxInfoHelper.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
@@ -13,6 +14,26 @@ function readVersion(): string {
   }
 }
 
+function readDisplayVersion(): string {
+  const version = readVersion();
+
+  try {
+    const commit = execSync("git rev-parse --short HEAD", {
+      cwd: process.cwd(),
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    if (!commit) {
+      return version;
+    }
+
+    return `${version}(${commit})`;
+  } catch {
+    return version;
+  }
+}
+
 function readAppName(): string {
   try {
     const userConfig = path.join(process.cwd(), "config.json");
@@ -25,4 +46,4 @@ function readAppName(): string {
   }
 }
 
-export { readVersion, readAppName };
+export { readVersion, readDisplayVersion, readAppName };


### PR DESCRIPTION
## Summary
- append the current short git commit hash to the local TeleBox display version
- reuse a shared helper so help and status show the same formatted version string
- fall back to the plain package version when git metadata is unavailable