### PR TITLE
fix(alias): move msg.edit before loadPlugins to ensure feedback is shown

### DIFF
--- a/src/plugin/alias.ts
+++ b/src/plugin/alias.ts
@@ -74,9 +74,9 @@ async function setAlias(args: string[], msg: Api.Message) {
   db.set(final, original);
   db.close();
 
-  await loadPlugins();
-
   await msg.edit({ text: `插件命令重命名成功，${final} -> ${original}` });
+
+  await loadPlugins();
 }
 
 async function delAlias(args: string[], msg: Api.Message) {

--- a/src/plugin/bf.ts
+++ b/src/plugin/bf.ts
@@ -690,11 +690,11 @@ class BfPlugin extends Plugin {
         try {
           const pluginManager = require("@utils/pluginManager");
           if (pluginManager.loadPlugins) {
-            await pluginManager.loadPlugins();
             await msg.edit({
               text: "✅ 恢复完成并已重载插件",
               parseMode: "html",
             });
+            await pluginManager.loadPlugins();
           } else {
             await msg.edit({
               text: "✅ 恢复完成，请重启程序",

--- a/src/plugin/prefix.ts
+++ b/src/plugin/prefix.ts
@@ -103,13 +103,13 @@ class PrefixPlugin extends Plugin {
       } catch (e) {
         persisted = false;
       }
-      await loadPlugins();
       await msg.edit({
         text: `✅ 已设置前缀: ${uniq
           .map((p) => `<code>${htmlEscape(p)}</code>`)
           .join(" • ")} ${persisted ? "(已写入 .env)" : "(.env 写入失败, 仅本次生效)"}`,
         parseMode: "html",
       });
+      await loadPlugins();
     },
   };
 }


### PR DESCRIPTION
loadPlugins() triggers a full runtime reload which destroys the old Telegram client. If msg.edit() is called after loadPlugins(), the old client reference is broken and the edit silently fails.

Moved msg.edit() before loadPlugins() in setAlias(), matching the existing pattern in delAlias().